### PR TITLE
Perf fixes

### DIFF
--- a/demos/motion-list-radium/Demo.jsx
+++ b/demos/motion-list-radium/Demo.jsx
@@ -9,6 +9,9 @@ export default class Demo extends Component {
   constructor(props) {
     super(props);
 
+    // Bind once to avoid passing a new callback each time
+    this.handleDestroy = this.handleDestroy.bind(this);
+
     this.state = {
       todos: {
         // key is creation date
@@ -172,16 +175,15 @@ export default class Demo extends Component {
                         const config = configs[key];
 
                         const {data: {isDone, text}, ...style} = config;
-
                         let itemStyle = _.merge({}, styles.item, style);
 
                         return (
                           <li key={key} style={itemStyle}>
                             <Item
-                              onClose={this.handleDestroy.bind(this, key)}
-                              style={styles.todoItem}
+                              onClose={this.handleDestroy}
                               label={config.data.text}
                               iconRight="X"
+                              id={key}
                             />
                           </li>
                         );

--- a/demos/motion-list-radium/Item.jsx
+++ b/demos/motion-list-radium/Item.jsx
@@ -9,13 +9,15 @@ export class Item extends Component {
     onClose: PropTypes.func,
     style: PropTypes.object,
     label: PropTypes.any,
-    children: PropTypes.any
+    children: PropTypes.any,
+    id: PropTypes.string,
   };
 
   getStyles() {
     return {
       container: {
-        lineHeight: '2.7rem'
+        lineHeight: '2.7rem',
+        ':hover': {fontWeight: 'bold'}
       },
       span: {
         marginTop: '.2rem',
@@ -43,9 +45,13 @@ export class Item extends Component {
     };
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return this.state !== nextState;
+  }
+
   _handleRightButtonClick(e) {
     if(e.type=="mouseup" || e.type=="touchend") return;
-    if (this.props.onClose) this.props.onClose(e);
+    if (this.props.onClose) this.props.onClose(this.props.id, e);
   }
 
   render() {


### PR DESCRIPTION
The primary issue is that Item is rerendering too much. Some thing we
can do to fix that:
- Usually `shouldComponentUpdate` can use the `shallowCompare` helper.
To avoid changing props, we can bind in the constructor and have the
child element pass data to the callback.
- We actually don’t need `shallowCompare`, since only the state will
change
- Add :hover styles to Item, to show that Radium actually runs